### PR TITLE
fix: Fixed link to helper script

### DIFF
--- a/snakemake_executor_plugin_google_lifesciences/__init__.py
+++ b/snakemake_executor_plugin_google_lifesciences/__init__.py
@@ -759,7 +759,7 @@ class Executor(RemoteExecutor):
         commands = [
             "/bin/bash",
             "-c",
-            f"wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save {self.bucket.name} /google/logs {self.gs_logs}/{job.name}/jobid_{job.jobid}",
+            f"wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake-executor-plugin-google-lifesciences/main/snakemake_executor_plugin_google_lifesciences/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save {self.bucket.name} /google/logs {self.gs_logs}/{job.name}/jobid_{job.jobid}",
         ]
 
         # Always run the action to generate log output
@@ -788,7 +788,7 @@ class Executor(RemoteExecutor):
             "mkdir -p /workdir && "
             "cd /workdir && "
             "wget -O /download.py "
-            "https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && "
+            "https://raw.githubusercontent.com/snakemake/snakemake-executor-plugin-google-lifesciences/main/snakemake_executor_plugin_google_lifesciences/google_lifesciences_helper.py && "
             "chmod +x /download.py && "
             "source activate snakemake || true && "
             f"python /download.py download {self.bucket.name} {self.pipeline_package} "


### PR DESCRIPTION
Links to the `google_lifesciences_helper.py` script were still directed toward their pre-plugin location in the main repo.